### PR TITLE
Issues #282 & #308: Refactor allocator property synopsis to avoid allocator_wrapper_t

### DIFF
--- a/wording.md
+++ b/wording.md
@@ -58,9 +58,14 @@ namespace execution {
 
   // Memory allocation properties:
 
-  struct default_allocator_t {} default_allocator;
-  template<class ProtoAllocator> struct allocator_wrapper_t { ProtoAllocator alloc; };
-  struct allocator_t { template<class ProtoAllocator> constexpr allocator_wrapper_t<ProtoAllocator> operator()(const ProtoAllocator& a) { return {a}; } } allocator;
+  template<class ProtoAllocator> struct allocator_t { ProtoAllocator a; };
+  template<> struct allocator_t<void> {
+    template<class ProtoAllocator>
+    constexpr allocator_t<ProtoAllocator> operator()(const ProtoAllocator& a) const {
+      return allocator_t<ProtoAllocator>{a};
+    }
+  };
+  constexpr allocator_t<void> allocator;
 
   // Executor type traits:
 
@@ -482,16 +487,21 @@ agents. *--end note*]
 
 ### Properties for customizing memory allocation
 
-  struct default_allocator_t {} default_allocator;
-  template<class ProtoAllocator> struct allocator_wrapper_t { ProtoAllocator alloc; };
-  struct allocator_t { template<class ProtoAllocator> constexpr allocator_wrapper_t<ProtoAllocator> operator()(const ProtoAllocator& a) { return {a}; } } allocator;
+  template<class ProtoAllocator> struct allocator_t { ProtoAllocator a; };
+  template<> struct allocator_t<void> {
+    template<class ProtoAllocator>
+    constexpr allocator_t<ProtoAllocator> operator()(const ProtoAllocator& a) const {
+      return allocator_t<ProtoAllocator>{a};
+    }
+  };
+  constexpr allocator_t<void> allocator;
 
 | Property | Requirements |
 |----------|--------------|
 | `default_allocator` | Executor implementations shall use a default implmentation defined allocator to allocate any memory required to store the submitted function object. |
 | `allocator(ProtoAllocator)` | Executor implementations shall use the supplied allocator to allocate any memory required to store the submitted function object. |
 
-[*Note:* As the `allocator(ProtoAllocator)` property requires a value to be provided when being set, it is required to be implemented such that it is callable with the `ProtoAllocator` parameter when used in `require` or `prefer` where the customization points accepts the result of the function call operator of `allocator_t`; `allocator_wrapper_t` and is passable as an instance when used in `query` where the customization point accepts an instance of `allocator_t`. *--end note*]
+[*Note:* As the `allocator(ProtoAllocator)` property requires a value to be provided when being set, it is required to be implemented such that it is callable with the `ProtoAllocator` parameter when used in `require` or `prefer` where the customization points accepts the result of the function call operator of `allocator_t<void>`; `allocator_t<ProtoAllocator>` and is passable as an instance when used in `query` where the customization point accepts an instance of `allocator_t<void>`. *--end note*]
 
 [*Note:* It is permitted for an allocator provided via the `allocator(ProtoAllocator)` property to be the same type as the allocator provided by the `default_allocator` property. *--end note*]
 
@@ -1384,7 +1394,7 @@ class C
     see-below require(execution::outstanding_work_t) const;
     see-below require(execution::not_outstanding_work_t) const;
     template<class ProtoAllocator>
-      see-below require(const execution::allocator_wrapper_t<ProtoAllocator>& a) const;
+    see-below require(const execution::allocator_t<ProtoAllocator>& a) const;
 
     bool running_in_this_thread() const noexcept;
 
@@ -1483,12 +1493,12 @@ returned executor object are identical to those of `*this`.
 
 ```
 template<class ProtoAllocator>
-  see-below require(const execution::allocator_wrapper_t<ProtoAllocator>& a) const;
+  see-below require(const execution::allocator_t<ProtoAllocator>& a) const;
 ```
 
 *Returns:* An executor object of an unspecified type conforming to these
 specifications, associated with the same thread pool as `*this`, with the
-`execution::allocator_wrapper_t<ProtoAllocator>` property established such that
+`execution::allocator_t<ProtoAllocator>` property established such that
 allocation and deallocation associated with function submission will be
 performed using a copy of `a.alloc`. All other properties of the returned
 executor object are identical to those of `*this`.


### PR DESCRIPTION
**Changes:**
* allocator_wrapper_t has been replaced by a specialization of
allocator_t for void, as described in #282.
* Make the function call operator of the now allocator_t<void>
const as described in #308.

**Fixes:**

#282, #308 