### PR TITLE
Acknowledge the issue of interoperation between executors & coroutines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,10 @@ CITEPROC= --filter pandoc-citeproc \
 	  --csl=acm-sig-proceedings-long-author-list.csl
 
 explanatory_pdf: explanatory.md explanatory_header.tex explanatory_metadata.yaml
-	pandoc $(PANDOC_FLAGS) $(CITEPROC) -H explanatory_header.tex explanatory_metadata.yaml explanatory.md -o P0761R1_Executors_Design_Document.pdf
+	pandoc $(PANDOC_FLAGS) $(CITEPROC) -H explanatory_header.tex explanatory_metadata.yaml explanatory.md -o P0761R2_Executors_Design_Document.pdf
 
 explanatory_html: explanatory.md explanatory_header.tex explanatory_metadata.yaml
-	pandoc $(PANDOC_FLAGS) $(CITEPROC) -H explanatory_header.tex explanatory_metadata.yaml explanatory.md -o P0761R1_Executors_Design_Document.html
+	pandoc $(PANDOC_FLAGS) $(CITEPROC) -H explanatory_header.tex explanatory_metadata.yaml explanatory.md -o P0761R2_Executors_Design_Document.html
 
 clean:
 	rm -f *0443*.pdf *0443*.html *0761*.pdf *0761*.html

--- a/explanatory.md
+++ b/explanatory.md
@@ -1,7 +1,7 @@
 ----------------    -------------------------------------
 Title:              Executors Design Document
 
-Document Number:    P0761R1
+Document Number:    P0761R2
 
 Authors:            Jared Hoberock, jhoberock@nvidia.com
 
@@ -17,7 +17,7 @@ Authors:            Jared Hoberock, jhoberock@nvidia.com
 
                     Michael Wong, michael@codeplay.com
 
-Date:               2017-10-16
+Date:               2018-02-??
 
 Audience:           SG1 - Concurrency and Parallelism
 
@@ -26,6 +26,12 @@ Reply-to:           sg1-exec@googlegroups.com
 Abstract:           This paper is a companion to [P0443](http://wg21.link/P0443) and describes the executors programming model it specifies. This paper is directed toward readers who want to understand in detail the mechanics of P0443's programming model, and the rationale underpinning the choices of that model's design.
 
 ------------------------------------------------------
+
+# Changelog
+
+## Revision 2
+
+* Acknowledge the issue of interoperation between executors and coroutines in Envisioned Extensions section.
 
 
 # Introduction
@@ -1697,6 +1703,14 @@ Transactional Memory TS can be integrated with executors. As TM constructs are
 compound statements of the form `atomic_noexcept  | atomic_commit |
 atomic_cancel  {<compound-statement> }` and `synchronized
 {<compound-statement> }`, it seems they can also apply with executors.
+
+**Coroutines.** Our proposal seeks to establish a uniform interface for
+supporting a variety of modes of execution for C++. Our design work has been
+driven primarily by the application areas spanned by the Concurrency,
+Parallelism, and Networking Technical Specifications. Meanwhile, the C++
+Coroutines Technical Specification, which represents another important
+mode of execution, has progressed independently. Robust interoperability
+between executors and coroutines ought to be explored.
 
 # Acknowledgements
 

--- a/explanatory.md
+++ b/explanatory.md
@@ -1710,7 +1710,10 @@ driven primarily by the application areas spanned by the Concurrency,
 Parallelism, and Networking Technical Specifications. Meanwhile, the C++
 Coroutines Technical Specification, which represents another important
 mode of execution, has progressed independently. Robust interoperability
-between executors and coroutines ought to be explored.
+between executors and coroutines ought to be explored. Based on prior
+experience with a similar executor model [@Kohlhoff16:P0286], we believe
+that interoperation is possible, although the exact form is still to be
+determined.
 
 # Acknowledgements
 

--- a/explanatory_metadata.yaml
+++ b/explanatory_metadata.yaml
@@ -301,4 +301,17 @@ references:
       - 15
   title: 'Working Draft, C++ Extensions for Ranges'
   URL: https://wg21.link/N4651
+
+- type: paper-conference
+  id: Kohlhoff16:P0286
+  author:
+  - family: Kohlhoff
+    given: Chris
+  issued:
+    date-parts:
+    - - 2016
+      - 2
+      - 14
+  title: 'A networking library extension to support co_await-based coroutines'
+  URL: https://wg21.link/P0286
 ...


### PR DESCRIPTION
This change adds a paragraph to the envisioned extensions section of the explanatory document mentioning the issue of interactions between executors and coroutines and also bumps the explanatory document's revision number.

Fixes #302