### PR TITLE
WIP: Refactoring the polymorphic executor

### DIFF
--- a/wording.md
+++ b/wording.md
@@ -803,7 +803,9 @@ This sub-clause contains templates that may be used to query the properties of a
 
 ## Polymorphic executor wrappers
 
-The polymorphic executor wrapper class has been written such that it could be separated from the rest of the proposal if nessesary.
+[*Commentary: The polymorphic executor wrapper class has been written such that it could be separated from the rest of the proposal if necessary.*]
+
+In several places in this section the operation `CONTAINS_PROPERTY(p, pn)` is used. All such uses mean `std::disjunction_v<std::is_same<p, pn>...>`.
 
 ### Class `bad_executor`
 
@@ -1038,7 +1040,7 @@ executor require(Property p) const;
 
 *Remarks:* This function shall not participate in overload resolution unless: `CONTAINS_PROPERTY(Property, SupportableProperties) && Property::is_requirable`.
 
-*Returns:* A polymorphic wrapper whose target is is the result of `execution::require(e, p)`, where `e` is the target object of `*this`.
+*Returns:* A polymorphic wrapper whose target is the result of `execution::require(e, p)`, where `e` is the target object of `*this`.
 
 ```
 template <class Property>
@@ -1203,14 +1205,14 @@ void swap(executor<SupportableProperties...>& a, executor<SupportableProperties.
 
 *Effects:* `a.swap(b)`.
 
-```
+```s
 template <class Property, class... SupportableProperties>
 executor prefer(const executor<SupportableProperties...>& e, Property p);
 ```
 
 *Remarks:* This function shall not participate in overload resolution unless: `CONTAINS_PROPERTY(Property, SupportableProperties)`.
 
-*Returns:* A polymorphic wrapper whose target is is the result of `execution::prefer(e, p)`, where `e` is the target object of `*this`.
+*Returns:* A polymorphic wrapper whose target is the result of `execution::prefer(e, p)`, where `e` is the target object of `*this`.
 
 ### Class `executor::context_type`
 

--- a/wording.md
+++ b/wording.md
@@ -961,11 +961,12 @@ template<class Executor> executor(Executor e);
 * and `can_query_v<Executor, P`, where `P` is each property in `SupportableProperties...`.
 
 *Effects:*
-* `*this` targets a copy of `e4` initialized with `std::move(e4)`, where:
-* If `CONTAINS_PROPERTY(execution::single_t, SupportableProperties)`, `e1` is the result of `execution::require(e, single_t)`, otherwise `e1` is `e`,
-* If `CONTAINS_PROPERTY(execution::bulk_t, SupportableProperties)`, `e2` is the result of `execution::require(e, bulk_t)`, otherwise `e2` is `e1`
-* If `CONTAINS_PROPERTY(execution::oneway_t, SupportableProperties)`, `e3` is the result of `execution::require(e, oneway_t)`, otherwise `e3` is `e2`
-* If `CONTAINS_PROPERTY(execution::twoway_t, SupportableProperties)`, `e4` is the result of `execution::require(e, twoway_t)`, otherwise `e4` is `e3`.
+* `*this` targets a copy of `e5` initialized with `std::move(e5)`, where:
+* If `CONTAINS_PROPERTY(execution::single_t, SupportableProperties)`, `e1` is the result of `execution::require(e, execution::single_t)`, otherwise `e1` is `e`,
+* If `CONTAINS_PROPERTY(execution::bulk_t, SupportableProperties)`, `e2` is the result of `execution::require(e, execution::bulk_t)`, otherwise `e2` is `e1`
+* If `CONTAINS_PROPERTY(execution::oneway_t, SupportableProperties)`, `e3` is the result of `execution::require(e, execution::oneway_t)`, otherwise `e3` is `e2`
+* If `CONTAINS_PROPERTY(execution::twoway_t, SupportableProperties)`, `e4` is the result of `execution::require(e, execution::twoway_t)`, otherwise `e4` is `e3`.
+* * If `CONTAINS_PROPERTY(execution::then_t, SupportableProperties)`, `e5` is the result of `execution::require(e, execution::then_t)`, otherwise `e5` is `e4`.
 
 ```
 template<class... OtherSupportableProperties> executor(executor<OtherSupportableProperties...> e);


### PR DESCRIPTION
**Changes**

* Make polymorphic executor templated on a variadic parameter pack of
property types.
* Introduce generic require, prefer and query member function templates
for the polymorphic executor.
* Add requirements on polymorphic executor require, prefer and query which require properties to be requireable, preferable and queryable according to new property form.
* Add requirements on polymorphic executor constructor which require
properties to be requireable, preferable and queryable according to new
property form.
* Remove requirement that execution functions call require() before
delegating to the target executor.
* Add missing template parameters from non-member functions.
* Remove prefer member function.
* Change e.require(p) to execution::require(e, p)
* Change e.query(p) to execution::query(e, p)
* Chnage Properties to SupportableProperties.
* Use correct wording for describing when a function should not
participate in overload resolution.
* Add CONTAINS_PROPERTY macro for checking when a property type exists
within a template parameter pack.
* Fix the wording for the return value of require and prefer.
* Add requirement that the interface changing properties be required on
construction.
* Add narrowing conversion constructor.
Add note to start of polymorphic executor wrapper section stating that
it had been written in a way which can be separated if necessary.