### PR TITLE
Allow implicit conversion of properties passed to executor's require/prefer/query functions. (#349)

### DIFF
--- a/wording.md
+++ b/wording.md
@@ -888,6 +888,8 @@ This sub-clause contains templates that may be used to query the properties of a
 
 In several places in this section the operation `CONTAINS_PROPERTY(p, pn)` is used. All such uses mean `std::disjunction_v<std::is_same<p, pn>...>`.
 
+In several places in this section the operation `FIND_CONVERTIBLE_PROPERTY(p, pn)` is used. All such uses mean the first type `P` in the parameter pack `pn` for which `std::is_convertible_v<p, P>` is `true`. If no such type `P` exists, the operation `FIND_CONVERTIBLE_PROPERTY(p, pn)` is ill-formed.
+
 ### Class `bad_executor`
 
 An exception of type `bad_executor` is thrown by `executor` member functions `execute`, `twoway_execute`, `bulk_execute`, and `bulk_twoway_execute` when the executor object has no target.
@@ -1114,7 +1116,7 @@ template <class Property>
 executor require(Property p) const;
 ```
 
-*Remarks:* This function shall not participate in overload resolution unless: `CONTAINS_PROPERTY(Property, SupportableProperties) && Property::is_requirable`.
+*Remarks:* This function shall not participate in overload resolution unless `FIND_CONVERTIBLE_PROPERTY(Property, SupportableProperties)::is_requirable` is well-formed and has the value `true`.
 
 *Returns:* A polymorphic wrapper whose target is the result of `execution::require(e, p)`, where `e` is the target object of `*this`.
 
@@ -1123,7 +1125,7 @@ template <class Property>
 executor query(Property p) const;
 ```
 
-*Remarks:* This function shall not participate in overload resolution unless: `CONTAINS_PROPERTY(Property, SupportableProperties)`.
+*Remarks:* This function shall not participate in overload resolution unless `FIND_CONVERTIBLE_PROPERTY(Property, SupportableProperties)` is well-formed.
 
 *Effects:* Performs `execution::query(e, p)`, where `e` is the target object of `*this`.
 
@@ -1286,7 +1288,7 @@ template <class Property, class... SupportableProperties>
 executor prefer(const executor<SupportableProperties...>& e, Property p);
 ```
 
-*Remarks:* This function shall not participate in overload resolution unless: `CONTAINS_PROPERTY(Property, SupportableProperties)`.
+*Remarks:* This function shall not participate in overload resolution unless `FIND_CONVERTIBLE_PROPERTY(Property, SupportableProperties)::is_preferable` is well-formed and has the value `true`.
 
 *Returns:* A polymorphic wrapper whose target is the result of `execution::prefer(e, p)`, where `e` is the target object of `*this`.
 


### PR DESCRIPTION
Addresses #349.