### PR TITLE
context_t::static_query_v should return decltype(auto) instead of bool

### DIFF
--- a/wording.md
+++ b/wording.md
@@ -408,7 +408,7 @@ If both `static_query_v` and `value()` are present, they shall return the same t
       using polymorphic_query_result_type = any; // TODO: alternatively consider void*, or simply omitting the type.
 
       template<class Executor>
-        static constexpr bool static_query_v
+        static constexpr decltype(auto) static_query_v
           = Executor::query(context_t());
     };
 


### PR DESCRIPTION
I think this is right -- unlike auto, decltype(auto) shouldn't decay references, which is what we'd want to preserve for returning a reference to a context

Fixes #361