### PR TITLE
Fix for typos in allocator_t

### DIFF
--- a/wording.md
+++ b/wording.md
@@ -807,11 +807,11 @@ The `allocator_t` property conforms to the following specification:
         }
 
         static constexpr ProtoAllocator value() const {
-          return a; // exposition only
+          return a_; // exposition only
         }
 
     private:
-        ProtoAllocator a; // exposition only
+        ProtoAllocator a_; // exposition only
     };
 
 | Property | Requirements |

--- a/wording.md
+++ b/wording.md
@@ -798,7 +798,7 @@ The `allocator_t` property conforms to the following specification:
         static constexpr bool is_preferable = true;
 
         template<class Executor>
-        static constexpr ProtoAllocator static_query_v
+        static constexpr auto static_query_v
           = Executor::query(allocator_t);
 
         template <typename OtherProtoAllocator>
@@ -806,7 +806,12 @@ The `allocator_t` property conforms to the following specification:
         	return allocator_t<OtherProtoAllocator>{a};
         }
 
-        static constexpr ProtoAllocator value() const { return a; }
+        static constexpr ProtoAllocator value() const {
+          return a; // exposition only
+        }
+
+    private:
+        ProtoAllocator a; // exposition only
     };
 
 | Property | Requirements |


### PR DESCRIPTION
allocator_t::static_query_v should return auto
Add exposition-only member to allocator_t

Fixes #369