### PR TITLE
Minor improvements to R11

### DIFF
--- a/wording.md
+++ b/wording.md
@@ -365,8 +365,6 @@ concept sender =
   sender-to-impl<S, sink_receiver>;
 ```
 
-None of a sender's copy constructor, destructor, equality comparison, or `swap` operation shall exit via an exception.
-
 None of these operations, nor a sender type's `submit` member function shall introduce data races as a result of concurrent invocations of those functions from different threads.
 
 An sender type's destructor shall not block pending completion of the submitted function objects. [*Note:* The ability to wait for completion of submitted function objects may be provided by the associated execution context. *--end note*]
@@ -375,7 +373,7 @@ In addition to the above requirements, types `S` and `R` model `sender` only if 
 
 In the Table below, 
 
-- `s` denotes a (possibly const) executor object of type `S`,
+- `s` denotes a (possibly const) sender object of type `S`,
 - `cr` denotes the function or receiver object `DECAY_COPY(std::forward<R>(r))` 
 - `r` denotes a function or receiver object of type `R&&` invocable as `cr()` and where `decay_t<R>` models `move_constructible`.
 

--- a/wording.md
+++ b/wording.md
@@ -290,13 +290,13 @@ The name `execution::schedule` denotes a customization point object. The express
 
 - `S.schedule()`, if that expression is valid and its type `N` models `Sender`. 
 
-- Otherwise, `schedule(S)`, if that expression is valid and its type `N` models `Sender` with overload resolution performed in a context that includes the declaration
+- Otherwise, `schedule(S)`, if that expression is valid and its type `N` models `sender` with overload resolution performed in a context that includes the declaration
 
         void schedule();
 
     and that does not include a declaration of `execution::schedule`. 
 
-- Otherwise, _`decay-copy`_`(S)` if the type `S` models `Sender`.
+- Otherwise, _`decay-copy`_`(S)` if the type `S` models `sender`.
 
 - Otherwise, `execution::schedule(S)` is ill-formed.
 
@@ -365,6 +365,24 @@ concept sender =
   sender-to-impl<S, sink_receiver>;
 ```
 
+None of a sender's copy constructor, destructor, equality comparison, or `swap` operation shall exit via an exception.
+
+None of these operations, nor a sender type's `submit` member function shall introduce data races as a result of concurrent invocations of those functions from different threads.
+
+An sender type's destructor shall not block pending completion of the submitted function objects. [*Note:* The ability to wait for completion of submitted function objects may be provided by the associated execution context. *--end note*]
+
+In addition to the above requirements, types `S` and `R` model `sender` only if they satisfy the requirements from the Table below.
+
+In the Table below, 
+
+- `s` denotes a (possibly const) executor object of type `S`,
+- `cr` denotes the function or receiver object `DECAY_COPY(std::forward<R>(r))` 
+- `r` denotes a function or receiver object of type `R&&` invocable as `cr()` and where `decay_t<R>` models `move_constructible`.
+
+| Expression | Return Type | Operational semantics |
+|------------|-------------|---------------------- |
+| `s.submit(r)` | `void` | Evaluates `DECAY_COPY(std::forward<R>(r))` on the calling thread to create `cr` that will be invoked at most once by an execution agent. <br/> May block pending completion of this invocation. <br/> Synchronizes with [intro.multithread] the invocation of `r`. <br/>Shall not propagate any exception thrown by the function object or any other function submitted to the executor. [*Note:* The treatment of exceptions thrown by one-way submitted functions is described by the `execution::oneway_exception_handler` property. The forward progress guarantee of the associated execution agent(s) is implementation defined. *--end note.*] |
+
 ### Concept `sender_to`
 
 XXX TODO The `sender_to` concept...
@@ -386,8 +404,8 @@ concept scheduler =
   copy_constructible<remove_cvref_t<S>> &&
   equality_comparable<remove_cvref_t<S>> &&
   requires(E&& e) {
-    execution::scheduler((S&&)s);
-  } // && sender<invoke_result_t<execution::scheduler, S>>
+    execution::schedule((S&&)s);
+  } // && sender<invoke_result_t<execution::schedule, S>>
   };
 ```
 
@@ -397,14 +415,14 @@ None of these operations, nor an scheduler type's `schedule` function, or associ
 
 For any two (possibly const) values `x1` and `x2` of some scheduler type `X`, `x1 == x2` shall return `true` only if `x1.query(p) == x2.query(p)` for every property `p` where both `x1.query(p)` and `x2.query(p)` are well-formed and result in a non-void type that is `EqualityComparable` (C++Std [equalitycomparable]). [*Note:* The above requirements imply that `x1 == x2` returns `true` if `x1` and `x2` can be interchanged with identical effects. An scheduler may conceptually contain additional properties which are not exposed by a named property type that can be observed via `execution::query`; in this case, it is up to the concrete scheduler implementation to decide if these properties affect equality. Returning `false` does not necessarily imply that the effects are not identical. *--end note*]
 
-An scheduler type's destructor shall not block pending completion of any function objects submitted to the returned object that models `Sender`. [*Note:* The ability to wait for completion of submitted function objects may be provided by the execution context that produced the scheduler. *--end note*]
+An scheduler type's destructor shall not block pending completion of any function objects submitted to the returned object that models `sender`. [*Note:* The ability to wait for completion of submitted function objects may be provided by the execution context that produced the scheduler. *--end note*]
 
 In addition to the above requirements, type `S` models `scheduler` only if it satisfies the requirements from at least one row in the Table below.
 
 In the Table below, 
 
 - `s` denotes a (possibly const) scheduler object of type `S`,
-- `N` denotes a type that models `Sender`, and
+- `N` denotes a type that models `sender`, and
 - `n` denotes a sender object of type `N`
 
 | Expression | Return Type | Operational semantics |
@@ -428,7 +446,7 @@ concept executor =
 
 None of an executor's copy constructor, destructor, equality comparison, or `swap` operation shall exit via an exception.
 
-None of these operations, nor an executor type's `execute` or `submit` functions, or associated query functions shall introduce data races as a result of concurrent invocations of those functions from different threads.
+None of these operations, nor an executor type's `execute` member function, or associated query functions shall introduce data races as a result of concurrent invocations of those functions from different threads.
 
 For any two (possibly const) values `x1` and `x2` of some executor type `X`, `x1 == x2` shall return `true` only if `x1.query(p) == x2.query(p)` for every property `p` where both `x1.query(p)` and `x2.query(p)` are well-formed and result in a non-void type that is `equality_comparable` (C++Std [equalitycomparable]). [*Note:* The above requirements imply that `x1 == x2` returns `true` if `x1` and `x2` can be interchanged with identical effects. An executor may conceptually contain additional properties which are not exposed by a named property type that can be observed via `execution::query`; in this case, it is up to the concrete executor implementation to decide if these properties affect equality. Returning `false` does not necessarily imply that the effects are not identical. *--end note*]
 
@@ -436,7 +454,7 @@ An executor type's destructor shall not block pending completion of the submitte
 
 For an executor type `E`, the expression `is_executor_v<E>` shall be a valid constant expression with the value `true`.
 
-In addition to the above requirements, types `E` and `F` model `executor` only if they satisfy the requirements from at least one row in the Table below.
+In addition to the above requirements, types `E` and `F` model `executor` only if they satisfy the requirements from the Table below.
 
 In the Table below, 
 
@@ -447,7 +465,6 @@ In the Table below,
 | Expression | Return Type | Operational semantics |
 |------------|-------------|---------------------- |
 | `e.execute(f)` | `void` | Evaluates `DECAY_COPY(std::forward<F>(f))` on the calling thread to create `cf` that will be invoked at most once by an execution agent. <br/> May block pending completion of this invocation. <br/> Synchronizes with [intro.multithread] the invocation of `f`. <br/>Shall not propagate any exception thrown by the function object or any other function submitted to the executor. [*Note:* The treatment of exceptions thrown by one-way submitted functions is described by the `execution::oneway_exception_handler` property. The forward progress guarantee of the associated execution agent(s) is implementation defined. *--end note.*] |
-| `e.submit(f)` | `void` | Evaluates `DECAY_COPY(std::forward<F>(f))` on the calling thread to create `cf` that will be invoked at most once by an execution agent. <br/> May block pending completion of this invocation. <br/> Synchronizes with [intro.multithread] the invocation of `f`. <br/>Shall not propagate any exception thrown by the function object or any other function submitted to the executor. [*Note:* The treatment of exceptions thrown by one-way submitted functions is described by the `execution::oneway_exception_handler` property. The forward progress guarantee of the associated execution agent(s) is implementation defined. *--end note.*] |
 
 ### No-op receiver
 


### PR DESCRIPTION
**Summary**

* Change remaining spellings of `Sender` to `sender`.
* Rename `execution::scheduler` to `executor::schedule`.
* Move wording for the `submit` member function to the `sender` concept
definition.

**Todo**

* I believe there is still more to be done to the wording of the `submit` member function, this change is largely to reflect the change to the `executor` concept.